### PR TITLE
Allow for arbitrary starting values for use during validation of TCG …

### DIFF
--- a/HashCalculator/Views/LandingPage.xaml
+++ b/HashCalculator/Views/LandingPage.xaml
@@ -52,6 +52,10 @@
                 <TextBlock Style="{StaticResource BodyTextBlockStyle}" Margin="0,4">A Trusted Platform Module (TPM) Platform Configuration Register (PCR) is a register that can 
                     only be reset to zero when the TPM device is reset and only modified by a one-way (or trap door) function called Extend. The Extend function concatenates the 
                     existing value of the PCR with the parameter of the function and calculates a hash. The digest of the hash becomes the new value of the PCR.</TextBlock>
+                <TextBlock Style="{StaticResource BodyTextBlockStyle}" Margin="0,4">For testing purposes, this tool allows you to start from an arbitrary value of the PCR, or to
+                    specify a Startup Locality. The Startup Locality follows special instructions different from the standard PCR extend operation, but is only valid as the 
+                    first event in a TCG Log and must be measured and extended by the platform firmware if applicable. In no context does a real TPM allow for PCR to be
+                    set to an arbitrary value outside of this initial Startup Locality special case, or the D-RTM reset from (-1) to 0.</TextBlock>
 
                 <TextBlock Style="{StaticResource SubtitleTextBlockStyle}">Hash Calculator Tool</TextBlock>
                 <TextBlock Style="{StaticResource BodyTextBlockStyle}" Margin="0,4">This tool allows to perform different kinds of hash calculations.</TextBlock>

--- a/HashCalculator/Views/Settings.xaml
+++ b/HashCalculator/Views/Settings.xaml
@@ -50,8 +50,6 @@
                 <Grid Margin="0,0,0,0">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
@@ -59,8 +57,6 @@
                     </Grid.ColumnDefinitions>
 
                     <CheckBox Grid.Row="0" Grid.ColumnSpan="2" x:Name="DontShowLandingPage" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="20,10" ToolTipService.ToolTip="Don't Show Landing page" Content="Don't Show Landing Page" Checked="DontShowLandingPage_Checked" Unchecked="DontShowLandingPage_Checked" />
-                    <TextBox Grid.Row="1" Grid.Column="0" Width="100" x:Name="InitialPCRValue" HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="20,10,10,10" ToolTipService.ToolTip="Set the value that PCR has after PCR reset" TextChanged="InitialPCRValue_TextChanged"/>
-                    <TextBlock Grid.Row="1" Grid.Column="1" x:Name="InitialPCRValueText" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="10,10,20,10" ToolTipService.ToolTip="Set the value that PCR has after PCR reset" Text="Initial PCR Value"/>
                 </Grid>
             </StackPanel>
         </ScrollViewer>

--- a/HashCalculator/Views/Settings.xaml.cs
+++ b/HashCalculator/Views/Settings.xaml.cs
@@ -14,7 +14,6 @@ namespace TPMPCRCalculator.Views
     {
         ApplicationDataContainer roamingSettings = null;
         const string DontShowLandingPageSetting = "DontShowLandingPage";
-        const string InitialPcrValue = "InitialPcrValue";
 
         public Settings()
         {
@@ -31,28 +30,11 @@ namespace TPMPCRCalculator.Views
             {
                 DontShowLandingPage.IsChecked = false;
             }
-            if (roamingSettings.Values[InitialPcrValue] != null)
-            {
-                InitialPCRValue.Text = roamingSettings.Values[InitialPcrValue].ToString();
-            }
-            else
-            {
-                InitialPCRValue.Text = "0";
-            }
         }
 
         private void DontShowLandingPage_Checked(object sender, RoutedEventArgs e)
         {
             roamingSettings.Values[DontShowLandingPageSetting] = DontShowLandingPage.IsChecked.ToString();
-        }
-
-        private void InitialPCRValue_TextChanged(object sender, TextChangedEventArgs e)
-        {
-            uint value = 0;
-            if (UInt32.TryParse(InitialPCRValue.Text, out value))
-            {
-                roamingSettings.Values[InitialPcrValue] = value;
-            }
         }
     }
 }

--- a/HashCalculator/Views/TpmPcrs.xaml
+++ b/HashCalculator/Views/TpmPcrs.xaml
@@ -57,6 +57,11 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
@@ -67,10 +72,27 @@
                     <TextBox Grid.Row="1" Grid.ColumnSpan="2" x:Name="PCR" Margin="20,10" Width="Auto" TextWrapping="Wrap" VerticalAlignment="Stretch" IsReadOnly="True" PlaceholderText="Current PCR value" FontFamily="Consolas" />
                     <ComboBox Grid.Row="2" Grid.Column="0" x:Name="ListOfAlgorithms"  Margin="20,10" HorizontalAlignment="Stretch" VerticalAlignment="Top" SelectionChanged="ListOfAlgorithms_SelectionChanged" />
                     <Button Grid.Row="2" Grid.Column="1" x:Name="ResetPcr" Content="Reset" Margin="0,10,20,10" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="ResetPcr_Click" />
-                    <TextBlock Grid.Row="3" Grid.ColumnSpan="2" Name="InputDescription" HorizontalAlignment="Left" Margin="20,10" TextWrapping="Wrap" Text="Insert data to extend here (a hash in hexadecimal representation):" Style="{StaticResource BodyTextBlockStyle}" VerticalAlignment="Top"/>
-                    <TextBox Grid.Row="4" Grid.ColumnSpan="2" x:Name="Input" Margin="20,10" Width="Auto" TextWrapping="Wrap" VerticalAlignment="Stretch" PlaceholderText="Insert hash to extend here" FontFamily="Consolas" />
-                    <Button Grid.Row="5" Grid.ColumnSpan="2" x:Name="Extend" Content="Extend" HorizontalAlignment="Stretch" Margin="20,10" VerticalAlignment="Top" Click="Extend_Click" />
-                    <TextBlock Grid.Row="6" Grid.ColumnSpan="2" x:Name="ExtendDescription" HorizontalAlignment="Stretch" Margin="20,10" VerticalAlignment="Top" TextWrapping="Wrap" Text="" Style="{StaticResource BodyTextBlockStyle}"/>
+                    
+                    <TextBlock Grid.Row="3" Grid.ColumnSpan="2" Name="StartupDescription" HorizontalAlignment="Left" Margin="20,10" TextWrapping="Wrap" Text="Set startup value (optional):" Style="{StaticResource BodyTextBlockStyle}" VerticalAlignment="Top"/>
+                    
+                    <!-- Radio buttons for startup type selection -->
+                    <StackPanel Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" Margin="20,10">
+                        <RadioButton x:Name="LocalityRadioButton" Content="Startup Locality integer" IsChecked="True" Margin="0,0,20,0" Checked="StartupTypeRadioButton_Checked" />
+                        <RadioButton x:Name="CustomValueRadioButton" Content="Custom Starting Value (hex)" Checked="StartupTypeRadioButton_Checked" />
+                    </StackPanel>
+                    
+                    <!-- Locality input -->
+                    <TextBox Grid.Row="5" Grid.Column="0" x:Name="LocalityInput" Margin="20,10" Width="Auto" TextWrapping="Wrap" VerticalAlignment="Stretch" PlaceholderText="Starting Locality 0" FontFamily="Consolas" MaxLength="2" />
+                    <Button Grid.Row="5" Grid.Column="1" x:Name="SetLocalityButton" Content="Set Startup Locality" Margin="0,10,20,10" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="SetStartupValue_Click" />
+                    
+                    <!-- Custom value input -->
+                    <TextBox Grid.Row="6" Grid.Column="0" x:Name="CustomValueInput" Margin="20,10" Width="Auto" TextWrapping="Wrap" VerticalAlignment="Stretch" PlaceholderText="Custom hex value (e.g., FFFFFFFFFF...)" FontFamily="Consolas" IsEnabled="False" />
+                    <Button Grid.Row="6" Grid.Column="1" x:Name="SetCustomValueButton" Content="Set Custom Value" Margin="0,10,20,10" HorizontalAlignment="Stretch" VerticalAlignment="Top" Click="SetStartupValue_Click" IsEnabled="False" />
+                    
+                    <TextBlock Grid.Row="7" Grid.ColumnSpan="2" Name="InputDescription" HorizontalAlignment="Left" Margin="20,10" TextWrapping="Wrap" Text="Insert data to extend here (a hash in hexadecimal representation):" Style="{StaticResource BodyTextBlockStyle}" VerticalAlignment="Top"/>
+                    <TextBox Grid.Row="8" Grid.ColumnSpan="2" x:Name="Input" Margin="20,10" Width="Auto" TextWrapping="Wrap" VerticalAlignment="Stretch" PlaceholderText="Insert hash to extend here" FontFamily="Consolas" />
+                    <Button Grid.Row="9" Grid.ColumnSpan="2" x:Name="Extend" Content="Extend" HorizontalAlignment="Stretch" Margin="20,10" VerticalAlignment="Top" Click="Extend_Click" />
+                    <TextBlock Grid.Row="10" Grid.ColumnSpan="2" x:Name="ExtendDescription" HorizontalAlignment="Stretch" Margin="20,10" VerticalAlignment="Top" TextWrapping="Wrap" Text="" Style="{StaticResource BodyTextBlockStyle}"/>
                 </Grid>
             </StackPanel>
         </ScrollViewer>

--- a/HashCalculator/Views/TpmPcrs.xaml.cs
+++ b/HashCalculator/Views/TpmPcrs.xaml.cs
@@ -14,12 +14,17 @@ namespace TPMPCRCalculator.Views
     {
         private ApplicationDataContainer m_RoamingSettings = null;
         private const string m_InitialPcrValue = "InitialPcrValue";
+        private const string m_CustomPcrValue = "CustomPcrValue";
+        private const string m_StartupType = "StartupType";
 
         private int m_CurrentAlgorithmIndex = 0;
         private readonly NavigationHelper m_NavigationHelper;
         private const string m_SettingSelectedHashAlgorithm = "pcrSelectedHash";
         private const string m_SettingInput = "pcrInput";
         private const string m_SettingPCR = "pcrPCR";
+        private const string m_SettingLocality = "pcrLocality";
+        private const string m_SettingCustomValue = "pcrCustomValue";
+        private const string m_SettingStartupType = "pcrStartupType";
         private const string m_ExtendDescriptionTemplate =
             "The Extend button concatenates the current PCR value with the provided input data (hash) " +
             "and then computes a hash of the concatenated value. " +
@@ -43,18 +48,84 @@ namespace TPMPCRCalculator.Views
             }
             ListOfAlgorithms.SelectedIndex = m_CurrentAlgorithmIndex;
 
+            // Set initial state for radio button controls after initialization
+            SetInitialControlState();
+
             ResetPcrText();
             ExtendDescription.Text = m_ExtendDescriptionTemplate;
+        }
+
+        private void SetInitialControlState()
+        {
+            // Ensure controls are available before setting their state
+            if (LocalityRadioButton != null && CustomValueRadioButton != null &&
+                LocalityInput != null && SetLocalityButton != null &&
+                CustomValueInput != null && SetCustomValueButton != null)
+            {
+                // Default to Locality mode
+                LocalityRadioButton.IsChecked = true;
+                LocalityInput.IsEnabled = true;
+                SetLocalityButton.IsEnabled = true;
+                CustomValueInput.IsEnabled = false;
+                SetCustomValueButton.IsEnabled = false;
+            }
+        }
+
+        private void StartupTypeRadioButton_Checked(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            // Ensure all controls are initialized before accessing them
+            if (LocalityRadioButton == null || CustomValueRadioButton == null || 
+                LocalityInput == null || SetLocalityButton == null ||
+                CustomValueInput == null || SetCustomValueButton == null)
+            {
+                return;
+            }
+
+            if (LocalityRadioButton.IsChecked == true)
+            {
+                // Enable locality controls, disable custom value controls
+                LocalityInput.IsEnabled = true;
+                SetLocalityButton.IsEnabled = true;
+                CustomValueInput.IsEnabled = false;
+                SetCustomValueButton.IsEnabled = false;
+            }
+            else if (CustomValueRadioButton.IsChecked == true)
+            {
+                // Enable custom value controls, disable locality controls
+                LocalityInput.IsEnabled = false;
+                SetLocalityButton.IsEnabled = false;
+                CustomValueInput.IsEnabled = true;
+                SetCustomValueButton.IsEnabled = true;
+            }
         }
 
         private void ResetPcrText()
         {
             if (ListOfAlgorithms.SelectedIndex != -1)
             {
-                PCR.Text = Worker.GetZeroDigestForAlgorithm((string)ListOfAlgorithms.SelectedItem);
-                if (m_RoamingSettings.Values[m_InitialPcrValue] != null)
+                string algorithmName = (string)ListOfAlgorithms.SelectedItem;
+                PCR.Text = Worker.GetZeroDigestForAlgorithm(algorithmName);
+                
+                // Check for stored startup values
+                if (m_RoamingSettings.Values[m_StartupType] != null)
                 {
-                    PCR.Text = Worker.GetZeroDigestForAlgorithm((string)ListOfAlgorithms.SelectedItem, (int)m_RoamingSettings.Values[m_InitialPcrValue]);
+                    string startupType = (string)m_RoamingSettings.Values[m_StartupType];
+                    if (startupType == "Locality" && m_RoamingSettings.Values[m_InitialPcrValue] != null)
+                    {
+                        PCR.Text = Worker.GetZeroDigestForAlgorithm(algorithmName, (int)m_RoamingSettings.Values[m_InitialPcrValue]);
+                    }
+                    else if (startupType == "Custom" && m_RoamingSettings.Values[m_CustomPcrValue] != null)
+                    {
+                        try
+                        {
+                            PCR.Text = Worker.GetCustomDigestForAlgorithm(algorithmName, (string)m_RoamingSettings.Values[m_CustomPcrValue]);
+                        }
+                        catch
+                        {
+                            // If custom value is invalid, fall back to zero digest
+                            PCR.Text = Worker.GetZeroDigestForAlgorithm(algorithmName);
+                        }
+                    }
                 }
             }
         }
@@ -63,6 +134,73 @@ namespace TPMPCRCalculator.Views
         {
             ResetPcrText();
             ExtendDescription.Text = m_ExtendDescriptionTemplate;
+        }
+
+        private void SetStartupValue_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            try
+            {
+                if (ListOfAlgorithms.SelectedIndex == -1)
+                {
+                    ExtendDescription.Text = "Please select a hash algorithm first.";
+                    return;
+                }
+
+                string algorithmName = (string)ListOfAlgorithms.SelectedItem;
+
+                if (LocalityRadioButton.IsChecked == true)
+                {
+                    // Handle locality setting
+                    int localityValue = 0;
+                    if (!string.IsNullOrWhiteSpace(LocalityInput.Text))
+                    {
+                        if (!int.TryParse(LocalityInput.Text, out localityValue))
+                        {
+                            ExtendDescription.Text = "Invalid locality value. Please enter a valid integer.";
+                            return;
+                        }
+                        if (localityValue < 0 || localityValue > 32)
+                        {
+                            ExtendDescription.Text = "Locality value must be between 0 and 32.";
+                            return;
+                        }
+                    }
+
+                    PCR.Text = Worker.GetZeroDigestForAlgorithm(algorithmName, localityValue);
+                    
+                    // Store the locality value and type for future resets
+                    m_RoamingSettings.Values[m_InitialPcrValue] = localityValue;
+                    m_RoamingSettings.Values[m_StartupType] = "Locality";
+                    m_RoamingSettings.Values.Remove(m_CustomPcrValue);
+                    
+                    ExtendDescription.Text = $"Startup locality set to {localityValue}. Current PCR value updated.";
+                }
+                else if (CustomValueRadioButton.IsChecked == true)
+                {
+                    // Handle custom value setting
+                    string customValue = CustomValueInput.Text?.Trim() ?? "";
+                    
+                    PCR.Text = Worker.GetCustomDigestForAlgorithm(algorithmName, customValue);
+                    
+                    // Store the custom value and type for future resets
+                    m_RoamingSettings.Values[m_CustomPcrValue] = customValue;
+                    m_RoamingSettings.Values[m_StartupType] = "Custom";
+                    m_RoamingSettings.Values.Remove(m_InitialPcrValue);
+                    
+                    if (string.IsNullOrWhiteSpace(customValue))
+                    {
+                        ExtendDescription.Text = "PCR reset to zero value.";
+                    }
+                    else
+                    {
+                        ExtendDescription.Text = $"Custom startup value set. Current PCR value updated to: {PCR.Text}";
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                ExtendDescription.Text = $"Error setting startup value: {ex.Message}";
+            }
         }
 
         private void Extend_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -150,6 +288,36 @@ namespace TPMPCRCalculator.Views
             {
                 PCR.Text = (string)SuspensionManager.SessionState[m_SettingPCR];
             }
+
+            if (SuspensionManager.SessionState.ContainsKey(m_SettingLocality))
+            {
+                LocalityInput.Text = (string)SuspensionManager.SessionState[m_SettingLocality];
+            }
+
+            if (SuspensionManager.SessionState.ContainsKey(m_SettingCustomValue))
+            {
+                CustomValueInput.Text = (string)SuspensionManager.SessionState[m_SettingCustomValue];
+            }
+
+            if (SuspensionManager.SessionState.ContainsKey(m_SettingStartupType))
+            {
+                string startupType = (string)SuspensionManager.SessionState[m_SettingStartupType];
+                
+                // Ensure controls are available before setting their state
+                if (LocalityRadioButton != null && CustomValueRadioButton != null)
+                {
+                    if (startupType == "Custom")
+                    {
+                        CustomValueRadioButton.IsChecked = true;
+                        StartupTypeRadioButton_Checked(CustomValueRadioButton, null);
+                    }
+                    else
+                    {
+                        LocalityRadioButton.IsChecked = true;
+                        StartupTypeRadioButton_Checked(LocalityRadioButton, null);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -165,6 +333,9 @@ namespace TPMPCRCalculator.Views
             SuspensionManager.SessionState[m_SettingSelectedHashAlgorithm] = ListOfAlgorithms.SelectedIndex.ToString();
             SuspensionManager.SessionState[m_SettingInput] = Input.Text;
             SuspensionManager.SessionState[m_SettingPCR] = PCR.Text;
+            SuspensionManager.SessionState[m_SettingLocality] = LocalityInput.Text;
+            SuspensionManager.SessionState[m_SettingCustomValue] = CustomValueInput.Text;
+            SuspensionManager.SessionState[m_SettingStartupType] = LocalityRadioButton.IsChecked == true ? "Locality" : "Custom";
         }
 
         #endregion

--- a/HashCalculator/Worker.cs
+++ b/HashCalculator/Worker.cs
@@ -51,6 +51,36 @@ namespace TPMPCRCalculator
             return ret;
         }
 
+        public static string GetCustomDigestForAlgorithm(string algorithm, string customValue)
+        {
+            if (string.IsNullOrWhiteSpace(customValue))
+            {
+                return GetZeroDigestForAlgorithm(algorithm);
+            }
+
+            uint digestSize = GetDigestSizeForAlgorithm(algorithm);
+            int expectedLength = (int)digestSize * 2; // Each byte is 2 hex characters
+
+            // Remove all whitespace characters
+            customValue = Regex.Replace(customValue, @"\s+", "");
+
+            // Validate hex string
+            if (!Regex.IsMatch(customValue, @"^[0-9A-Fa-f]*$"))
+            {
+                throw new Exception($"\'{customValue}\' is not a valid hexadecimal string.");
+            }
+
+            if (customValue.Length > expectedLength)
+            {
+                throw new Exception($"Custom value \'{customValue}\' is too long for algorithm {algorithm}. Expected maximum {expectedLength} characters, got {customValue.Length}.");
+            }
+
+            // Pad with leading zeros if necessary
+            customValue = customValue.PadLeft(expectedLength, '0');
+
+            return customValue;
+        }
+
         public static byte[] ComputeHash(string algorithm, byte[] input)
         {
             HashAlgorithmProvider sha = HashAlgorithmProvider.OpenAlgorithm(algorithm);


### PR DESCRIPTION
(Written with / by AI)

Existing code has support for startup localities but nothing else. This version lets you set a startup integer like was intended, but also lets you set arbitrary values for the initial value. This is helpful for both setting to (-1) in the DRTM scenario, or for being able to start verifying extends in the middle of a log without having to extend all prior events.